### PR TITLE
fix: resolve broken images caused by Bilder/ vs bilder/ case mismatch

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,6 @@
 module.exports = function (eleventyConfig) {
   // Passthrough copy
-  eleventyConfig.addPassthroughCopy({ "bilder": "bilder" });
+  eleventyConfig.addPassthroughCopy({ "Bilder": "bilder" });
   eleventyConfig.addPassthroughCopy({ "fonts": "fonts" });
 
   // News collection sorted by date descending

--- a/src/training.njk
+++ b/src/training.njk
@@ -16,7 +16,7 @@ permalink: /training/
 <section class="py-28 px-8 max-md:py-16 max-md:px-6">
   <div class="max-w-300 mx-auto">
     <div>
-      <img src="/Bilder/tuishou1.jpg" alt="Tuishou – Push Hands Training" class="max-md:hidden float-right ml-10 mb-4 w-2/5 rounded-sm">
+      <img src="/bilder/tuishou1.jpg" alt="Tuishou – Push Hands Training" class="max-md:hidden float-right ml-10 mb-4 w-2/5 rounded-sm">
       <p class="text-[1.05rem] leading-relaxed text-muted">Unser Training ist für jedes Alter und jedes Fitnesslevel geeignet. Du lernst Schritt für Schritt, ohne Leistungsdruck. Fachbegriffe werden erklärt. Vorkenntnisse nicht erforderlich.</p>
 
       <h2 class="font-heading text-[clamp(1.8rem,4vw,2.8rem)] mt-12 mb-6 clear-both">Was dich im Training erwartet</h2>

--- a/src/ueber-uns.njk
+++ b/src/ueber-uns.njk
@@ -74,7 +74,7 @@ permalink: /ueber-uns/
         <h2 class="font-heading text-[clamp(1.8rem,4vw,2.8rem)] mb-6">Von Yang Luchan bis heute</h2>
         <p class="text-[1.05rem] leading-relaxed text-muted max-w-175">Der Yang-Stil wurde Mitte des 19. Jahrhunderts von Yang Luchan begründet und von seinem Enkel Yang Chengfu zur heute weltweit verbreiteten Form entwickelt. Großmeister Yang Jun führt diese Tradition in der 6. Generation fort. Wir sind Teil dieser lebendigen Linie.</p>
       </div>
-      <img class="w-full object-cover" loading="lazy" src="/Bilder/Yangfamilytree.webp" alt="Yang Familienstammbaum">
+      <img class="w-full object-cover" loading="lazy" src="/bilder/Yangfamilytree.webp" alt="Yang Familienstammbaum">
     </div>
   </div>
 </section>


### PR DESCRIPTION
On Linux (case-sensitive filesystem) the Eleventy passthrough copy was
sourcing from "bilder" (lowercase) while the actual directory is "Bilder",
so no images were ever copied into the build output.  Also normalise two
template references that used /Bilder/ to the consistent lowercase /bilder/.

https://claude.ai/code/session_01Ab55wAYtDDn362GxjxpRew